### PR TITLE
Fix for outlook

### DIFF
--- a/src/Providers/Outlook.php
+++ b/src/Providers/Outlook.php
@@ -22,7 +22,7 @@ class Outlook implements EmailRulesInterface
     {
         return [
             'live.com'        => [
-                'rules' => EmailNormalizer::PLUS_TAG | EmailNormalizer::USERNAME_DOTS
+                'rules' => EmailNormalizer::PLUS_TAG
             ],
             'hotmail.com'     => [
                 'rules' => EmailNormalizer::PLUS_TAG


### PR DESCRIPTION
No need to have live.com to normalize periods in user part of the email

https://answers.microsoft.com/en-us/outlook_com/forum/all/does-dotperiod-matter-in-livecom-email-address/4bc7cbab-022a-4409-bff3-28bbab22a8a8

[abin@launchpad6.com](mailto:abin@launchpad6.com)